### PR TITLE
Fix devDependencies merge conflict markers in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,19 +21,16 @@
     "recharts": "^3.2.1"
   },
   "devDependencies": {
-codex/setup-project-with-eslint-and-vitest
+    "@tailwindcss/postcss": "^4.1.14",
     "@testing-library/jest-dom": "^6.9.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-=======
-    "@tailwindcss/postcss": "^4.1.14",
-main
     "@types/node": "^22.14.0",
     "@typescript-eslint/eslint-plugin": "^8.45.0",
     "@typescript-eslint/parser": "^8.45.0",
     "@vitejs/plugin-react": "^5.0.0",
-codex/setup-project-with-eslint-and-vitest
     "@vitest/coverage-v8": "^3.2.4",
+    "autoprefixer": "^10.4.21",
     "eslint": "^9.36.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
@@ -41,12 +38,9 @@ codex/setup-project-with-eslint-and-vitest
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "jsdom": "^27.0.0",
-    "prettier": "^3.6.2",
-=======
-    "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
+    "prettier": "^3.6.2",
     "tailwindcss": "^4.1.14",
-main
     "typescript": "~5.8.2",
     "vite": "^6.2.0",
     "vite-tsconfig-paths": "^5.1.4",


### PR DESCRIPTION
## Summary
- remove merge conflict markers from the devDependencies block in package.json
- consolidate the devDependencies list into a single valid JSON object

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd6fbcc104832e8a943d1c7f194905