### PR TITLE
feat: refresh dashboard hero and cards

### DIFF
--- a/src/components/DashboardCard.tsx
+++ b/src/components/DashboardCard.tsx
@@ -9,13 +9,11 @@ interface DashboardCardProps {
 
 const DashboardCard: React.FC<DashboardCardProps> = ({ title, value, icon, color }) => {
   return (
-    <div className="bg-primary p-5 rounded-xl shadow-md border border-border flex items-center space-x-4 transition-transform hover:scale-105">
-      <div className={`p-3 rounded-full ${color}`}>
-        {icon}
-      </div>
+    <div className="bg-white/90 backdrop-blur p-5 rounded-2xl shadow-lg ring-1 ring-white/50 flex items-center space-x-4 transition-transform duration-200 hover:-translate-y-1">
+      <div className={`p-3 rounded-full bg-gradient-to-br ${color} shadow-md shadow-black/10`}>{icon}</div>
       <div>
-        <p className="text-sm font-medium text-text-secondary">{title}</p>
-        <p className="text-2xl font-bold text-text-primary">{value}</p>
+        <p className="text-sm font-medium text-slate-500">{title}</p>
+        <p className="text-2xl font-bold text-slate-900">{value}</p>
       </div>
     </div>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useData } from '../context/DataContext';
 import DashboardCard from '../components/DashboardCard';
-import { PackageIcon, DollarSignIcon, BarChartIcon, ShoppingCartIcon, WarningIcon } from '../components/Icons';
+import { PackageIcon, DollarSignIcon, BarChartIcon, ShoppingCartIcon, WarningIcon, DocumentTextIcon, ArchiveIcon } from '../components/Icons';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LineChart, Line } from 'recharts';
 import { Link } from 'react-router-dom';
 import { formatCurrency } from '../utils/helpers';
@@ -46,37 +46,55 @@ const Dashboard: React.FC = () => {
 
 
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-        <DashboardCard 
-          title="Valor del Stock (Costo)" 
-          value={formatCurrency(totalStockValue)} 
-          icon={<PackageIcon className="h-6 w-6 text-indigo-600" />}
-          color="bg-indigo-100"
+    <div className="space-y-8">
+      <section className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 px-6 py-12 text-white shadow-2xl">
+        <div className="absolute inset-0 opacity-40 mix-blend-soft-light bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.4),_transparent_55%)]" aria-hidden="true" />
+        <div className="relative z-10 max-w-3xl space-y-4">
+          <span className="inline-flex items-center rounded-full bg-white/15 px-4 py-1 text-xs font-semibold uppercase tracking-widest shadow-sm ring-1 ring-white/40">Panel general</span>
+          <h1 className="text-3xl font-bold leading-tight sm:text-4xl">Bienvenido al tablero de gestión de Parfum</h1>
+          <p className="text-base text-indigo-100 sm:text-lg">Visualiza el pulso de tu negocio de un vistazo: inventario, ventas y métricas clave en un solo lugar para tomar decisiones estratégicas más rápido.</p>
+          <div>
+            <Link
+              to="/reports"
+              className="inline-flex items-center gap-2 rounded-full bg-white/20 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-indigo-900/30 ring-1 ring-white/40 backdrop-blur transition hover:bg-white/30"
+            >
+              <DocumentTextIcon className="h-5 w-5" />
+              Ver reportes
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+        <DashboardCard
+          title="Valor del Stock (Costo)"
+          value={formatCurrency(totalStockValue)}
+          icon={<PackageIcon className="h-6 w-6 text-white" />}
+          color="from-indigo-500 to-indigo-600"
         />
-        <DashboardCard 
-          title="Ingresos Totales" 
+        <DashboardCard
+          title="Ingresos Totales"
           value={formatCurrency(totalRevenue)}
-          icon={<DollarSignIcon className="h-6 w-6 text-green-600" />}
-          color="bg-green-100"
+          icon={<DollarSignIcon className="h-6 w-6 text-white" />}
+          color="from-emerald-500 to-emerald-600"
         />
-        <DashboardCard 
-          title="Ganancia Total" 
+        <DashboardCard
+          title="Ganancia Total"
           value={formatCurrency(totalProfit)}
-          icon={<BarChartIcon className="h-6 w-6 text-amber-600" />}
-          color="bg-amber-100"
+          icon={<BarChartIcon className="h-6 w-6 text-white" />}
+          color="from-amber-500 to-orange-500"
         />
-        <DashboardCard 
-          title="Total de Ventas" 
+        <DashboardCard
+          title="Total de Ventas"
           value={sales.length.toString()}
-          icon={<ShoppingCartIcon className="h-6 w-6 text-pink-600" />}
-          color="bg-pink-100"
+          icon={<ShoppingCartIcon className="h-6 w-6 text-white" />}
+          color="from-rose-500 to-rose-600"
         />
       </div>
-      
+
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="lg:col-span-2 bg-primary p-4 sm:p-6 rounded-xl shadow-md border border-border">
-            <h2 className="text-xl font-semibold mb-4 text-text-primary">Ventas por Producto (Top 10)</h2>
+        <div className="lg:col-span-2 rounded-3xl bg-white/80 p-6 backdrop-blur shadow-xl ring-1 ring-slate-200/60">
+            <h2 className="mb-4 text-2xl font-semibold tracking-tight text-slate-900">Ventas por Producto (Top 10)</h2>
             <ResponsiveContainer width="100%" height={400}>
                 <BarChart data={topProductsData} margin={{ top: 5, right: 20, left: -10, bottom: 90 }}>
                     <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
@@ -92,34 +110,38 @@ const Dashboard: React.FC = () => {
                 </BarChart>
             </ResponsiveContainer>
         </div>
-        <div className="bg-primary p-4 sm:p-6 rounded-xl shadow-md border border-border">
-          <h2 className="text-xl font-semibold mb-4 text-text-primary">Items con Bajo Stock</h2>
+        <div className="rounded-3xl bg-slate-900/80 p-6 backdrop-blur shadow-xl ring-1 ring-slate-800/60">
+          <h2 className="mb-4 text-2xl font-semibold tracking-tight text-white">Items con Bajo Stock</h2>
           {lowStockItems.length > 0 ? (
-            <ul className="space-y-3 max-h-[380px] overflow-y-auto">
+            <ul className="max-h-[380px] space-y-3 overflow-y-auto pr-1">
               {lowStockItems.map(item => (
-                <li key={item.id} className="flex items-center justify-between p-2 rounded-lg hover:bg-secondary">
+                <li key={item.id} className="flex items-center justify-between rounded-xl border border-white/5 bg-white/5 p-3 transition hover:bg-white/10">
                   <div>
-                    <p className="font-medium text-text-primary">{item.name}</p>
-                    <p className="text-sm text-text-secondary">SKU: {item.id}</p>
+                    <p className="font-medium text-white">{item.name}</p>
+                    <p className="text-sm text-slate-300">SKU: {item.id}</p>
                   </div>
-                  <span className="flex items-center text-sm font-bold text-warning bg-yellow-100 px-2 py-1 rounded-full">
-                    <WarningIcon className="h-4 w-4 mr-1"/>
+                  <span className="flex items-center rounded-full bg-amber-400/20 px-3 py-1 text-sm font-semibold text-amber-200">
+                    <WarningIcon className="mr-1 h-4 w-4"/>
                     {item.stock} unidades
                   </span>
                 </li>
               ))}
             </ul>
           ) : (
-            <p className="text-text-secondary mt-10 text-center">No hay productos con bajo stock.</p>
+            <p className="mt-10 text-center text-slate-300">No hay productos con bajo stock.</p>
           )}
-          <Link to="/inventory" className="mt-4 block text-center w-full bg-accent hover:bg-accent-hover text-white font-bold py-2 px-4 rounded-lg transition-colors">
+          <Link
+            to="/inventory"
+            className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-amber-300 via-orange-400 to-rose-400 px-5 py-3 text-sm font-semibold uppercase tracking-wide text-slate-900 shadow-md shadow-amber-500/30 transition hover:shadow-lg"
+          >
+            <ArchiveIcon className="h-5 w-5" />
             Ir a Inventario
           </Link>
         </div>
       </div>
 
-      <div className="bg-primary p-4 sm:p-6 rounded-xl shadow-md border border-border">
-          <h2 className="text-xl font-semibold mb-4 text-text-primary">Ventas a lo largo del Tiempo</h2>
+      <div className="rounded-3xl bg-white/80 p-6 backdrop-blur shadow-xl ring-1 ring-slate-200/60">
+          <h2 className="mb-4 text-2xl font-semibold tracking-tight text-slate-900">Ventas a lo largo del Tiempo</h2>
           <ResponsiveContainer width="100%" height={400}>
             <LineChart data={salesOverTimeData} margin={{ top: 5, right: 20, left: -10, bottom: 20 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />


### PR DESCRIPTION
## Summary
- add a gradient hero section with a reports CTA to the dashboard
- restyle KPI cards and analytic sections with glassmorphism-inspired surfaces
- update the inventory call-to-action button to match the refreshed aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd730feab4832eb114148119cc8156