### PR TITLE
Add gradient base styles for root layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,14 @@
 @tailwind utilities;
 
 @layer base {
+  body {
+    @apply min-h-screen bg-gradient-to-br from-[#eef2ff] via-[#f5f3ff] to-[#fdf2f8] font-sans antialiased text-text-primary;
+  }
+
+  #root {
+    @apply min-h-screen flex;
+  }
+
   @media print {
     body * {
       visibility: hidden;


### PR DESCRIPTION
## Summary
- apply a soft gradient background and font utilities to the body base layer
- ensure the root element stretches as a flex container across the screen while keeping print styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7312e310832eaa801f0f250ac19e