### PR TITLE
Fix Tailwind build errors from @apply usage

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,11 +4,17 @@
 
 @layer base {
   body {
-    @apply min-h-screen bg-gradient-to-br from-[#eef2ff] via-[#f5f3ff] to-[#fdf2f8] font-sans antialiased text-text-primary;
+    font-family: 'Inter', system-ui, sans-serif;
+    min-height: 100vh;
+    background-image: linear-gradient(135deg, #eef2ff, #f5f3ff, #fdf2f8);
+    color: #1f2937;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   #root {
-    @apply min-h-screen flex;
+    min-height: 100vh;
+    display: flex;
   }
 
   @media print {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,9 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+      },
       colors: {
         background: '#f4f7fc',
         primary: '#ffffff',


### PR DESCRIPTION
## Summary
- replace the Tailwind `@apply` directives in the global stylesheet with plain CSS equivalents to avoid unknown utility errors during builds
- extend the Tailwind theme with an `Inter`-based sans-serif font stack for consistent typography

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd759deac0832e92af3f6f089a5548