### PR TITLE
Refactor tables to reusable DataTable component

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+
+type Align = 'left' | 'center' | 'right';
+
+type Variant = 'text' | 'badge';
+
+const classNames = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(' ');
+
+export interface DataTableColumn<T> {
+  key: string;
+  header: React.ReactNode;
+  accessor?: keyof T;
+  render?: (row: T, index: number) => React.ReactNode;
+  className?: string;
+  align?: Align;
+  variant?: Variant;
+}
+
+export interface DataTableActions<T> {
+  header?: React.ReactNode;
+  render: (row: T, index: number) => React.ReactNode;
+  className?: string;
+  align?: Align;
+}
+
+export interface DataTableProps<T> {
+  columns: Array<DataTableColumn<T>>;
+  rows: T[];
+  rowKey: (row: T, index: number) => string;
+  emptyState: React.ReactNode;
+  actions?: DataTableActions<T>;
+  scrollClassName?: string;
+}
+
+const getAlignmentClass = (align?: Align) => {
+  if (align === 'center') return 'text-center';
+  if (align === 'right') return 'text-right';
+  return 'text-left';
+};
+
+function DataTable<T>({
+  columns,
+  rows,
+  rowKey,
+  emptyState,
+  actions,
+  scrollClassName,
+}: DataTableProps<T>) {
+  if (rows.length === 0) {
+    return <div className="data-table-empty">{emptyState}</div>;
+  }
+
+  return (
+    <div className="data-table-wrapper">
+      <div className={classNames('data-table-scroll', scrollClassName)}>
+        <table className="data-table">
+          <thead>
+            <tr>
+              {columns.map(column => (
+                <th
+                  key={column.key}
+                  className={classNames(
+                    'data-table-head-cell',
+                    getAlignmentClass(column.align),
+                    column.className,
+                  )}
+                >
+                  {column.header}
+                </th>
+              ))}
+              {actions && (
+                <th
+                  className={classNames(
+                    'data-table-head-cell',
+                    getAlignmentClass(actions.align),
+                    actions.className,
+                  )}
+                >
+                  {actions.header ?? 'Acciones'}
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => (
+              <tr key={rowKey(row, index)} className="data-table-row">
+                {columns.map(column => {
+                  const rawValue = column.accessor ? (row[column.accessor] as unknown) : undefined;
+                  const content = column.render ? column.render(row, index) : rawValue;
+                  const shouldUseBadge =
+                    column.variant === 'badge' ||
+                    (column.variant === undefined && typeof rawValue === 'number');
+
+                  return (
+                    <td
+                      key={column.key}
+                      className={classNames(
+                        'data-table-cell',
+                        getAlignmentClass(column.align),
+                        column.className,
+                      )}
+                    >
+                      {shouldUseBadge ? <span className="badge-soft">{content}</span> : content}
+                    </td>
+                  );
+                })}
+                {actions && (
+                  <td
+                    className={classNames(
+                      'data-table-cell',
+                      getAlignmentClass(actions.align),
+                      actions.className,
+                    )}
+                  >
+                    {actions.render(row, index)}
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default DataTable;

--- a/src/index.css
+++ b/src/index.css
@@ -35,3 +35,97 @@
     }
   }
 }
+
+@layer components {
+  .data-table-wrapper {
+    position: relative;
+  }
+
+  .data-table-scroll {
+    overflow-x: auto;
+  }
+
+  .data-table {
+    width: 100%;
+    border-spacing: 0;
+  }
+
+  .data-table-head-cell {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    backdrop-filter: blur(12px);
+    background-color: rgba(255, 255, 255, 0.6);
+    text-align: left;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #6b7280;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+  }
+
+  .data-table-row {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .data-table-row:nth-child(odd) {
+    background-color: rgba(255, 255, 255, 0.7);
+  }
+
+  .data-table-row:nth-child(even) {
+    background-color: rgba(255, 255, 255, 0.4);
+  }
+
+  .data-table-row:hover {
+    background-color: rgba(255, 255, 255, 0.8);
+  }
+
+  .data-table-cell {
+    padding: 0.75rem 1rem;
+    vertical-align: middle;
+    font-size: 0.875rem;
+    color: #1f2937;
+  }
+
+  .data-table-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 4rem 1rem;
+    text-align: center;
+  }
+}
+
+@layer utilities {
+  .badge-soft,
+  .badge-success,
+  .badge-danger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    border-radius: 9999px;
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .badge-soft {
+    background-color: rgba(99, 102, 241, 0.12);
+    color: #4f46e5;
+  }
+
+  .badge-success {
+    background-color: rgba(16, 185, 129, 0.18);
+    color: #047857;
+  }
+
+  .badge-danger {
+    background-color: rgba(239, 68, 68, 0.18);
+    color: #b91c1c;
+  }
+}

--- a/src/pages/CashFlow.tsx
+++ b/src/pages/CashFlow.tsx
@@ -3,6 +3,7 @@ import { useData } from '../context/DataContext';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import DashboardCard from '../components/DashboardCard';
 import { DollarSignIcon, TrendingUpIcon, TrendingDownIcon } from '../components/Icons';
+import DataTable from '../components/DataTable';
 import { AdjustmentType } from '../types';
 import { formatCurrency } from '../utils/helpers';
 
@@ -145,48 +146,42 @@ const CashFlow: React.FC = () => {
       
       <div className="bg-primary rounded-xl shadow-md overflow-hidden border border-border">
         <h2 className="text-xl font-bold p-4 border-b">Detalle de Movimientos</h2>
-        <div className="overflow-x-auto max-h-96">
-          <table className="w-full">
-            <thead className="bg-secondary sticky top-0">
-              <tr>
-                <th className="p-4 font-semibold text-left">Fecha</th>
-                <th className="p-4 font-semibold text-left">Descripción</th>
-                <th className="p-4 font-semibold text-left">Tipo</th>
-                <th className="p-4 font-semibold text-right">Monto</th>
-                <th className="p-4 font-semibold text-right">Saldo</th>
-              </tr>
-            </thead>
-            <tbody>
-              {processedData.transactionsWithBalance.length > 0 ? (
-                processedData.transactionsWithBalance.map((t, index) => (
-                  <tr key={index} className="border-b border-border hover:bg-secondary/50">
-                    <td className="p-4">{t.date}</td>
-                    <td className="p-4">{t.description}</td>
-                    <td className="p-4">
-                      <span className={`px-2 py-1 text-xs font-semibold rounded-full ${
-                        t.type === 'Ingreso' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
-                      }`}>
-                        {t.type}
-                      </span>
-                    </td>
-                    <td className={`p-4 text-right font-medium ${
-                      t.type === 'Ingreso' ? 'text-success' : 'text-danger'
-                    }`}>
-                      {t.type === 'Ingreso' ? '+' : '-'}{formatCurrency(t.amount)}
-                    </td>
-                    <td className="p-4 text-right font-semibold">{formatCurrency(t.balance)}</td>
-                  </tr>
-                ))
-              ) : (
-                <tr>
-                  <td colSpan={5} className="text-center py-10 text-text-secondary">
-                    No hay transacciones en el período seleccionado.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
+        <DataTable
+          columns={[
+            { key: 'date', header: 'Fecha', accessor: 'date' },
+            { key: 'description', header: 'Descripción', accessor: 'description', className: 'min-w-[220px]' },
+            {
+              key: 'type',
+              header: 'Tipo',
+              render: transaction => (
+                <span className={transaction.type === 'Ingreso' ? 'badge-success' : 'badge-danger'}>{transaction.type}</span>
+              ),
+            },
+            {
+              key: 'amount',
+              header: 'Monto',
+              align: 'right',
+              render: transaction => (
+                <span className={transaction.type === 'Ingreso' ? 'text-success font-medium' : 'text-danger font-medium'}>
+                  {transaction.type === 'Ingreso' ? '+' : '-'}
+                  {formatCurrency(transaction.amount)}
+                </span>
+              ),
+            },
+            {
+              key: 'balance',
+              header: 'Saldo',
+              align: 'right',
+              render: transaction => <span className="font-semibold">{formatCurrency(transaction.balance)}</span>,
+            },
+          ]}
+          rows={processedData.transactionsWithBalance}
+          rowKey={(transaction, index) => `${transaction.date}-${index}`}
+          emptyState={
+            <p className="text-text-secondary">No hay transacciones en el período seleccionado.</p>
+          }
+          scrollClassName="max-h-96 overflow-y-auto"
+        />
       </div>
     </div>
   );

--- a/src/pages/Customers.tsx
+++ b/src/pages/Customers.tsx
@@ -4,6 +4,7 @@ import { Customer } from '../types';
 import { useNotification } from '../context/NotificationContext';
 import Modal from '../components/Modal';
 import { EditIcon, DeleteIcon, UsersIcon, ArrowUpIcon, ArrowDownIcon } from '../components/Icons';
+import DataTable from '../components/DataTable';
 import { Link } from 'react-router-dom';
 import { formatCurrency } from '../utils/helpers';
 
@@ -115,9 +116,14 @@ const Customers: React.FC = () => {
     };
     
     const SortableHeader: React.FC<{ sortKey: SortableCustomerKeys; children: React.ReactNode }> = ({ sortKey, children }) => (
-        <th className="p-4 font-semibold cursor-pointer text-left" onClick={() => requestSort(sortKey)}>
-            <div className="flex items-center">{children} {getSortIcon(sortKey)}</div>
-        </th>
+        <button
+            type="button"
+            onClick={() => requestSort(sortKey)}
+            className="flex items-center gap-1 font-semibold text-text-primary hover:text-accent focus:outline-none"
+        >
+            {children}
+            {getSortIcon(sortKey)}
+        </button>
     );
 
     return (
@@ -138,49 +144,66 @@ const Customers: React.FC = () => {
                 </div>
             </div>
             <div className="bg-primary rounded-xl shadow-md overflow-hidden border border-border">
-                {sortedCustomers.length === 0 ? (
-                    <div className="text-center py-20">
-                        <UsersIcon className="mx-auto h-16 w-16 text-gray-300" />
-                        <h3 className="mt-4 text-lg font-semibold text-text-primary">No hay clientes registrados</h3>
-                        <p className="mt-1 text-sm text-text-secondary">Haz clic en "Agregar Cliente" para empezar.</p>
-                    </div>
-                ) : (
-                    <div className="overflow-x-auto">
-                        <table className="w-full">
-                            <thead className="bg-secondary">
-                                <tr>
-                                    <SortableHeader sortKey="name">Nombre</SortableHeader>
-                                    <SortableHeader sortKey="phone">Teléfono</SortableHeader>
-                                    <SortableHeader sortKey="email">Email</SortableHeader>
-                                    <th className="p-4 font-semibold text-left">Compras</th>
-                                    <th className="p-4 font-semibold text-left">Total Gastado</th>
-                                    <th className="p-4 font-semibold text-left">Acciones</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {sortedCustomers.map(customer => (
-                                    <tr key={customer.id} className="border-b border-border hover:bg-secondary/50 transition-colors">
-                                        <td className="p-4 font-medium">
-                                            <Link to={`/customers/${customer.id}`} className="text-accent hover:underline">
-                                                {customer.name}
-                                            </Link>
-                                        </td>
-                                        <td className="p-4">{customer.phone}</td>
-                                        <td className="p-4">{customer.email}</td>
-                                        <td className="p-4">{customer.purchaseCount}</td>
-                                        <td className="p-4 font-semibold">{formatCurrency(customer.totalSpent)}</td>
-                                        <td className="p-4">
-                                            <div className="flex items-center space-x-2">
-                                                <button onClick={() => handleOpenModal(customer)} className="text-accent hover:text-accent-hover p-1"><EditIcon className="w-5 h-5" /></button>
-                                                <button onClick={() => handleDelete(customer.id)} className="text-danger hover:opacity-75 p-1"><DeleteIcon className="w-5 h-5" /></button>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                )}
+                <DataTable
+                    columns={[
+                        {
+                            key: 'name',
+                            header: <SortableHeader sortKey="name">Nombre</SortableHeader>,
+                            render: customer => (
+                                <Link to={`/customers/${customer.id}`} className="text-accent hover:underline font-medium">
+                                    {customer.name}
+                                </Link>
+                            ),
+                            className: 'min-w-[200px]'
+                        },
+                        {
+                            key: 'phone',
+                            header: <SortableHeader sortKey="phone">Teléfono</SortableHeader>,
+                            accessor: 'phone',
+                            className: 'min-w-[160px]'
+                        },
+                        {
+                            key: 'email',
+                            header: <SortableHeader sortKey="email">Email</SortableHeader>,
+                            accessor: 'email',
+                            className: 'min-w-[200px]'
+                        },
+                        {
+                            key: 'purchaseCount',
+                            header: 'Compras',
+                            accessor: 'purchaseCount',
+                            variant: 'badge'
+                        },
+                        {
+                            key: 'totalSpent',
+                            header: 'Total Gastado',
+                            render: customer => formatCurrency(customer.totalSpent),
+                            className: 'font-semibold'
+                        }
+                    ]}
+                    rows={sortedCustomers}
+                    rowKey={customer => customer.id}
+                    emptyState={
+                        <>
+                            <UsersIcon className="mx-auto h-16 w-16 text-gray-300" />
+                            <h3 className="text-lg font-semibold text-text-primary">No hay clientes registrados</h3>
+                            <p className="text-sm text-text-secondary">Haz clic en "Agregar Cliente" para empezar.</p>
+                        </>
+                    }
+                    actions={{
+                        render: customer => (
+                            <div className="flex items-center space-x-2">
+                                <button onClick={() => handleOpenModal(customer)} className="text-accent hover:text-accent-hover p-1">
+                                    <EditIcon className="w-5 h-5" />
+                                </button>
+                                <button onClick={() => handleDelete(customer.id)} className="text-danger hover:opacity-75 p-1">
+                                    <DeleteIcon className="w-5 h-5" />
+                                </button>
+                            </div>
+                        ),
+                        className: 'min-w-[140px]'
+                    }}
+                />
             </div>
 
             <Modal isOpen={isModalOpen} onClose={handleCloseModal} title={editingCustomer ? "Editar Cliente" : "Agregar Nuevo Cliente"}>

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useData } from '../context/DataContext';
 import { AdjustmentType } from '../types';
 import { formatCurrency } from '../utils/helpers';
+import DataTable from '../components/DataTable';
 
 type ReportType = 'sales' | 'inventory' | 'profit';
 
@@ -82,14 +83,27 @@ const Reports: React.FC = () => {
             <div><span className="font-semibold">Ingresos Totales:</span> {formatCurrency(generatedReport.summary.totalRevenue)}</div>
             <div><span className="font-semibold">Productos Vendidos:</span> {generatedReport.summary.totalItemsSold}</div>
           </div>
-          <table className="w-full text-left">
-            <thead><tr><th className="p-2 bg-secondary">Fecha</th><th className="p-2 bg-secondary">Producto</th><th className="p-2 bg-secondary">Cantidad</th><th className="p-2 bg-secondary">Total</th></tr></thead>
-            <tbody>
-              {generatedReport.data.map((s: any) => (
-                <tr key={s.id} className="border-b"><td className="p-2">{s.date}</td><td className="p-2">{products.find(p=>p.id === s.productId)?.name}</td><td className="p-2">{s.quantity}</td><td className="p-2">{formatCurrency(s.total)}</td></tr>
-              ))}
-            </tbody>
-          </table>
+          <DataTable
+            columns={[
+              { key: 'date', header: 'Fecha', accessor: 'date' },
+              {
+                key: 'product',
+                header: 'Producto',
+                render: (sale: any) => products.find(p => p.id === sale.productId)?.name || sale.productId,
+                className: 'min-w-[200px]'
+              },
+              { key: 'quantity', header: 'Cantidad', accessor: 'quantity', variant: 'badge' },
+              {
+                key: 'total',
+                header: 'Total',
+                render: (sale: any) => formatCurrency(sale.total),
+                className: 'font-semibold'
+              }
+            ]}
+            rows={generatedReport.data}
+            rowKey={(sale: any) => sale.id}
+            emptyState={<p className="text-text-secondary">No hay ventas en el período seleccionado.</p>}
+          />
         </div>
       );
     }
@@ -103,14 +117,28 @@ const Reports: React.FC = () => {
             <div><span className="font-semibold">Unidades Vendibles:</span> {generatedReport.summary.totalUnits}</div>
             <div><span className="font-semibold">Unidades Tester:</span> {generatedReport.summary.totalTesters}</div>
           </div>
-          <table className="w-full text-left">
-            <thead><tr><th className="p-2 bg-secondary">SKU</th><th className="p-2 bg-secondary">Producto</th><th className="p-2 bg-secondary">Stock Vendible</th><th className="p-2 bg-secondary">Testers</th><th className="p-2 bg-secondary">Valor (Costo)</th></tr></thead>
-            <tbody>
-              {generatedReport.data.map((p: any) => (
-                <tr key={p.id} className="border-b"><td className="p-2">{p.id}</td><td className="p-2">{p.name}</td><td className="p-2">{p.stock}</td><td className="p-2">{p.testerStock}</td><td className="p-2">{formatCurrency(p.stock * p.costPrice)}</td></tr>
-              ))}
-            </tbody>
-          </table>
+          <DataTable
+            columns={[
+              {
+                key: 'sku',
+                header: 'SKU',
+                render: (product: any) => <span className="font-mono text-sm">{product.id}</span>,
+                className: 'whitespace-nowrap'
+              },
+              { key: 'name', header: 'Producto', accessor: 'name', className: 'min-w-[200px]' },
+              { key: 'stock', header: 'Stock Vendible', accessor: 'stock', variant: 'badge' },
+              { key: 'testerStock', header: 'Testers', accessor: 'testerStock', variant: 'badge' },
+              {
+                key: 'stockValue',
+                header: 'Valor (Costo)',
+                render: (product: any) => formatCurrency(product.stock * product.costPrice),
+                className: 'font-semibold'
+              }
+            ]}
+            rows={generatedReport.data}
+            rowKey={(product: any) => product.id}
+            emptyState={<p className="text-text-secondary">No hay inventario para mostrar.</p>}
+          />
         </div>
       );
     }
@@ -129,14 +157,22 @@ const Reports: React.FC = () => {
             </div>
           </div>
           <h4 className="text-lg font-semibold mb-2">Detalle de Ventas del Período</h4>
-          <table className="w-full text-left">
-            <thead><tr><th className="p-2 bg-secondary">Fecha</th><th className="p-2 bg-secondary">Producto</th><th className="p-2 bg-secondary">Ingreso</th><th className="p-2 bg-secondary">Costo</th><th className="p-2 bg-secondary">Ganancia Bruta</th></tr></thead>
-            <tbody>
-              {generatedReport.data.map((s: any) => (
-                <tr key={s.id} className="border-b"><td className="p-2">{s.date}</td><td className="p-2">{s.productName}</td><td className="p-2">{formatCurrency(s.total)}</td><td className="p-2">{formatCurrency(s.cost)}</td><td className="p-2">{formatCurrency(s.profit)}</td></tr>
-              ))}
-            </tbody>
-          </table>
+          <DataTable
+            columns={[
+              { key: 'date', header: 'Fecha', accessor: 'date' },
+              { key: 'productName', header: 'Producto', accessor: 'productName', className: 'min-w-[200px]' },
+              { key: 'revenue', header: 'Ingreso', render: (sale: any) => formatCurrency(sale.total) },
+              { key: 'cost', header: 'Costo', render: (sale: any) => formatCurrency(sale.cost) },
+              {
+                key: 'profit',
+                header: 'Ganancia Bruta',
+                render: (sale: any) => <span className="text-success font-semibold">{formatCurrency(sale.profit)}</span>
+              }
+            ]}
+            rows={generatedReport.data}
+            rowKey={(sale: any) => sale.id}
+            emptyState={<p className="text-text-secondary">No hay datos de rentabilidad para el período seleccionado.</p>}
+          />
         </div>
       );
     }

--- a/src/pages/Sales.tsx
+++ b/src/pages/Sales.tsx
@@ -5,6 +5,7 @@ import { Sale } from '../types';
 import { EditIcon, DeleteIcon, DollarSignIcon, ArrowUpIcon, ArrowDownIcon } from '../components/Icons';
 import { useNotification } from '../context/NotificationContext';
 import { formatCurrency } from '../utils/helpers';
+import DataTable from '../components/DataTable';
 
 type SortableSaleKeys = keyof Sale | 'productName' | 'customerName';
 
@@ -143,9 +144,14 @@ const Sales: React.FC = () => {
   };
   
   const SortableHeader: React.FC<{ sortKey: SortableSaleKeys; children: React.ReactNode }> = ({ sortKey, children }) => (
-    <th className="p-4 font-semibold cursor-pointer text-left" onClick={() => requestSort(sortKey)}>
-      <div className="flex items-center">{children} {getSortIcon(sortKey)}</div>
-    </th>
+    <button
+      type="button"
+      onClick={() => requestSort(sortKey)}
+      className="flex items-center gap-1 font-semibold text-text-primary hover:text-accent focus:outline-none"
+    >
+      {children}
+      {getSortIcon(sortKey)}
+    </button>
   );
 
   return (
@@ -158,49 +164,71 @@ const Sales: React.FC = () => {
       </div>
 
       <div className="bg-primary rounded-xl shadow-md overflow-hidden border border-border">
-        {sales.length === 0 ? (
-          <div className="text-center py-20">
-            <DollarSignIcon className="mx-auto h-16 w-16 text-gray-300" />
-            <h3 className="mt-4 text-lg font-semibold text-text-primary">No hay ventas registradas</h3>
-            <p className="mt-1 text-sm text-text-secondary">Usa la "Venta Rápida" o registra una venta manual para empezar.</p>
-          </div>
-        ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="bg-secondary">
-              <tr>
-                <SortableHeader sortKey="date">Fecha</SortableHeader>
-                <SortableHeader sortKey="productName">Producto</SortableHeader>
-                <SortableHeader sortKey="customerName">Cliente</SortableHeader>
-                <SortableHeader sortKey="quantity">Cantidad</SortableHeader>
-                <SortableHeader sortKey="unitPrice">Precio Unitario</SortableHeader>
-                <SortableHeader sortKey="total">Total</SortableHeader>
-                <th className="p-4 font-semibold text-left">Acciones</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sortedSales.map(sale => {
-                return (
-                  <tr key={sale.id} className="border-b border-border hover:bg-secondary/50 transition-colors">
-                    <td className="p-4 text-left">{sale.date}</td>
-                    <td className="p-4 text-left">{sale.productName}</td>
-                    <td className="p-4 text-left">{sale.customerName}</td>
-                    <td className="p-4 text-left">{sale.quantity}</td>
-                    <td className="p-4 text-left">{formatCurrency(sale.unitPrice)}</td>
-                    <td className="p-4 font-medium text-left">{formatCurrency(sale.total)}</td>
-                     <td className="p-4 text-left">
-                      <div className="flex items-center space-x-2">
-                        <button onClick={() => handleOpenModalForEdit(sale)} className="text-accent hover:text-accent-hover p-1"><EditIcon className="w-5 h-5"/></button>
-                        <button onClick={() => handleDelete(sale.id)} className="text-danger hover:opacity-75 p-1"><DeleteIcon className="w-5 h-5"/></button>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-        )}
+        <DataTable
+          columns={[
+            {
+              key: 'date',
+              header: <SortableHeader sortKey="date">Fecha</SortableHeader>,
+              accessor: 'date',
+            },
+            {
+              key: 'productName',
+              header: <SortableHeader sortKey="productName">Producto</SortableHeader>,
+              accessor: 'productName',
+              className: 'min-w-[180px]',
+            },
+            {
+              key: 'customerName',
+              header: <SortableHeader sortKey="customerName">Cliente</SortableHeader>,
+              accessor: 'customerName',
+              className: 'min-w-[160px]',
+            },
+            {
+              key: 'quantity',
+              header: <SortableHeader sortKey="quantity">Cantidad</SortableHeader>,
+              accessor: 'quantity',
+              variant: 'badge',
+            },
+            {
+              key: 'unitPrice',
+              header: <SortableHeader sortKey="unitPrice">Precio Unitario</SortableHeader>,
+              render: sale => formatCurrency(sale.unitPrice),
+            },
+            {
+              key: 'total',
+              header: <SortableHeader sortKey="total">Total</SortableHeader>,
+              render: sale => formatCurrency(sale.total),
+              className: 'font-semibold',
+            },
+          ]}
+          rows={sortedSales}
+          rowKey={sale => sale.id}
+          emptyState={
+            <>
+              <DollarSignIcon className="mx-auto h-16 w-16 text-gray-300" />
+              <h3 className="text-lg font-semibold text-text-primary">No hay ventas registradas</h3>
+              <p className="text-sm text-text-secondary">
+                Usa la "Venta Rápida" o registra una venta manual para empezar.
+              </p>
+            </>
+          }
+          actions={{
+            render: sale => (
+              <div className="flex items-center space-x-2">
+                <button
+                  onClick={() => handleOpenModalForEdit(sale)}
+                  className="text-accent hover:text-accent-hover p-1"
+                >
+                  <EditIcon className="w-5 h-5" />
+                </button>
+                <button onClick={() => handleDelete(sale.id)} className="text-danger hover:opacity-75 p-1">
+                  <DeleteIcon className="w-5 h-5" />
+                </button>
+              </div>
+            ),
+            className: 'min-w-[120px]',
+          }}
+        />
       </div>
       
       <Modal isOpen={isModalOpen} onClose={handleCloseModal} title={editingSale ? "Editar Venta" : "Registrar Nueva Venta Manual"}>


### PR DESCRIPTION
## Summary
- add a reusable `DataTable` component with support for sticky headers, zebra rows, badges, and action columns
- refactor inventory, sales, customers, reports, and cash flow tables to use the new component
- introduce shared table and badge styles for consistent presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7f4d9ea4832ebd46c4a243a90216